### PR TITLE
doc: add redirect for the removed calculator page

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -1,6 +1,13 @@
 ### a dictionary of redirections
 #old path: new path
 
+
+# Removing the consistency calculator page (starting from version 5.4)
+# needs to be replaced with the following when 5.4 is released:
+# /stable/cql/consistency-calculator.html: https://opensource.docs.scylladb.com/stable/cql/consistency.html
+
+/master/cql/consistency-calculator.html: https://opensource.docs.scylladb.com/master/cql/consistency.html
+
 # moving Glossary under Reference (starting from version 5.3)
 # needs to be replaced with the following when 5.3 is released:
 # /stable/glossary.html: /stable/reference/glossary.html


### PR DESCRIPTION
Refs: scylladb/scylladb#14554

This commit adds a redirection for the removed consistency calculator page.
The change will be released with ScyllaDB 5.4.

**Merge only after https://github.com/scylladb/scylladb/pull/14554 is merged.**