### PR TITLE
add the get-started documents

### DIFF
--- a/docs/get-started/data-modeling/best-practices.rst
+++ b/docs/get-started/data-modeling/best-practices.rst
@@ -1,0 +1,100 @@
+====================================
+Data Modeling Best Practices
+====================================
+
+These additional topics provide a broader perspective on data modeling, query 
+design, schema design, and best practices when working with ScyllaDB or similar 
+distributed NoSQL databases.
+
+**Partition Key Selection**
+
+Choose your partition keys to avoid imbalances in your clusters. Imbalanced 
+partitions can lead to performance bottlenecks, which impact overall cluster 
+performance. Balancing the distribution of data across partitions is crucial 
+to ensure all nodes are effectively utilized in your cluster.
+
+Let's consider a scenario with poor partition key selection:
+
+.. code::
+
+    CREATE TABLE my_keyspace.messages_bad (
+        message_id uuid PRIMARY KEY,
+        user_id uuid,
+        message_text text,
+        created_at timestamp
+    );
+
+In this model, the partition key is chosen as ``message_id``, which is a globally 
+unique identifier for each message. This choice results in poor partition key 
+selection because it doesn't distribute data evenly across partitions. As 
+a result, messages from popular users with many posts will create hot 
+partitions, as all their messages will be concentrated in a single partition.
+
+A better solution for partition key selection would look like:
+
+.. code::
+
+    CREATE TABLE my_keyspace.messages_good (
+      user_id uuid,
+      message_id uuid,
+      message_text text,
+      created_at timestamp,
+      PRIMARY KEY (user_id, message_id)
+    );
+
+In this improved model, the partition key is chosen as ``user_id``, which is 
+the unique identifier for each user. This choice results in even data 
+distribution across partitions because each user's messages are distributed 
+across multiple partitions based on their ``user_id``. Popular users with many 
+posts won't create hot partitions, as their messages are distributed across 
+the cluster. This approach ensures that all nodes in the cluster are 
+effectively utilized, preventing performance bottlenecks.
+
+**Tombstones and Delete Workloads**
+
+If your workload involves frequent deletes, it’s crucial that you understand 
+the implications of tombstones on your read path. Tombstones are markers for 
+deleted data and can negatively affect query performance if not managed 
+effectively.
+
+Let's consider a data model for storing user messages:
+
+.. code::
+
+    CREATE TABLE my_keyspace.user_messages (
+        user_id uuid,
+        message_id uuid,
+        message_text text,
+        is_deleted boolean,
+        PRIMARY KEY (user_id, message_id)
+    );
+
+In this table, each user can have multiple messages, identified by 
+``user_id`` and ``message_id``.
+The ``is_deleted`` column is used to mark messages as deleted (true) or not 
+deleted (false). When a user deletes a message, a tombstone is created to mark 
+the message as deleted. Tombstones are necessary for data consistency, but can 
+negatively affect query performance, especially when there are frequent delete 
+operations.
+
+Adjust your compaction strategy to account for tombstones and optimize query 
+performance in scenarios with heavy delete operations.
+
+To optimize query performance in scenarios with heavy delete operations, you 
+can `adjust the compaction strategy and use TTL <https://opensource.docs.scylladb.com/stable/kb/ttl-facts.html>`_ 
+(Time-to-Live) to handle tombstones more efficiently. ScyllaDB allows you to 
+choose different compaction strategies. In scenarios with heavy delete 
+workloads, consider using a compaction strategy that efficiently handles 
+tombstones, such as the ``TimeWindowCompactionStrategy``.
+
+.. code::
+
+    ALTER TABLE my_keyspace.user_messages 
+     WITH default_time_to_live = 2592000 
+     AND compaction = {'class': 'TimeWindowCompactionStrategy', 'base_time_seconds': 86400, 'max_sstable_age_days': 14};
+
+
+This setup, with a 30-day TTL (``default_time_to_live = 2592000``) and 
+a 14-day maximum SSTable age ``('max_sstable_age_days': 14)``, is suited for 
+time-sensitive data scenarios where keeping data beyond a month is 
+unnecessary, and the most relevant data is always from the last two weeks.

--- a/docs/get-started/data-modeling/index.rst
+++ b/docs/get-started/data-modeling/index.rst
@@ -1,0 +1,28 @@
+===============
+Data Modeling
+===============
+
+Data modeling is the process of defining the structure and relationships of 
+your data in ScyllaDB. It involves making important decisions about how data 
+will be organized, stored, and retrieved.
+
+Data modeling in NoSQL database such as ScyllaDB differs from traditional 
+relational databases. 
+
+A practical approach when data modeling for ScyllaDB is to adopt a query-first 
+data model, where you design your data model around the queries that it needs 
+to execute.
+
+
+.. toctree::
+  :titlesonly:
+
+  query-design
+  schema-design
+  best-practices
+
+
+  
+
+
+

--- a/docs/get-started/data-modeling/query-design.rst
+++ b/docs/get-started/data-modeling/query-design.rst
@@ -1,0 +1,52 @@
+====================
+Query Design
+====================
+
+Your data model is heavily influenced by query efficiency. Effective partitioning, clustering columns and denormalization are key considerations for optimizing data access patterns.
+
+The way data is partitioned plays a pivotal role in how it’s accessed. An efficient partitioning strategy ensures that data is evenly distributed across the cluster, minimizing hotspots. For example:
+
+.. code::
+
+  CREATE TABLE my_keyspace.user_activities (
+    user_id uuid,
+    activity_date date,
+    activity_details text,
+    PRIMARY KEY (user_id, activity_date)
+  );
+
+In this table, ``user_id`` is the partition key, ensuring activities are grouped by user, and ``activity_date`` is the clustering column, ordering activities within each user's partition.
+
+Clustering columns dictate the order of rows within a partition. They are crucial for range queries. For example:
+
+.. code::
+
+  CREATE TABLE my_keyspace.user_logs (
+    user_id uuid,
+    log_time timestamp,
+    log_message text,
+    PRIMARY KEY (user_id, log_time)
+  );
+  
+Here, logs are ordered by ``log_time`` within each ``user_id`` partition, making it efficient to query logs over a time range for a specific user.  
+
+Your query design should also be optimized for efficient and effective queries 
+to retrieve and manipulate data. Query optimization aims to minimize resource 
+usage and latency while achieving maximum throughput.
+
+Indexing is another important aspect of query design. We have already 
+introduced the basic concept of primary keys, which can be made up of two 
+parts: the partition key and optional clustering columns. ScyllaDB also 
+supports secondary indexes for non-primary key columns. `Secondary indexes <https://opensource.docs.scylladb.com/stable/using-scylla/secondary-indexes.html>_` can 
+improve query flexibility, but it’s important to consider their impact on 
+performance. For example:
+
+.. code::
+
+  CREATE INDEX ON my_keyspace.user_activities (activity_date);
+
+This index allows querying activities by date regardless of the user. However, secondary indexes might lead to additional overhead and should be used when necessary.
+
+An alternative to secondary indexes, `materialized views <https://opensource.docs.scylladb.com/stable/cql/mv.html>`_ keep a separate, indexed table based on the base table's data. They can be more performant for reads.
+
+ScyllaDB supports CQL for querying data. Learning and mastering CQL is crucial for designing queries. For more detailed instructions, please see our `documentation <https://opensource.docs.scylladb.com/stable/cql/>`_.

--- a/docs/get-started/data-modeling/schema-design.rst
+++ b/docs/get-started/data-modeling/schema-design.rst
@@ -1,0 +1,41 @@
+=======================
+Schema Design
+=======================
+
+When adopting a query-first data model, the same constraints need to be applied 
+to the schema design. 
+While schema design can evolve to meet your changing application needs, there 
+are certain choices you will need to make to get the most value out of ScyllaDB. 
+This further reinforces the concept of adopting a query-first data model.
+
+**Data Types**
+
+Selecting the appropriate `data type <https://opensource.docs.scylladb.com/stable/cql/types.html>`_ for your columns is critical for both 
+physical storage and logical query performance in your data model. You will 
+need to consider factors such as data size, indexing, and sorting.
+
+Let's say you're designing a table to store information about e-commerce 
+products, and one of the attributes you want to capture is the product's price. 
+The choice of data type for the "price" column is crucial for efficient storage 
+and query performance.
+
+.. code::
+
+    CREATE TABLE my_keyspace.products (
+        product_id uuid PRIMARY KEY,
+        product_name text,
+        price decimal,
+        description text
+    );
+
+In this example, for the``price`` column, we've chosen the decimal data type. 
+This data type is suitable for storing precise numerical values, such as 
+prices, as it preserves decimal precision.
+Choosing decimal over other numeric data types like float or double is 
+essential when dealing with financial data to avoid issues with rounding errors.
+
+You can efficiently index and query prices using the decimal data type, 
+ensuring fast and precise searches for products within specific price ranges. 
+When you need to sort products by price, the decimal data type maintains the 
+correct order, even for values with different decimal precision.
+

--- a/docs/get-started/develop-with-scylladb/connect-apps.rst
+++ b/docs/get-started/develop-with-scylladb/connect-apps.rst
@@ -1,0 +1,110 @@
+=======================
+Connect an Application
+=======================
+
+To connect your application to ScyllaDB, you need to:
+
+#. :doc:`Install the relevant driver </get-started/develop-with-scylladb/install-drivers>` 
+   for your application language.
+ 
+   This step involves setting up a driver that is compatible with ScyllaDB. 
+   The driver acts as the link between your application and ScyllaDB, enabling 
+   your application to communicate with the database.
+
+#. Modify your application code to connect the driver. 
+
+   The following is some boilerplate code to help familiarize yourself with 
+   connecting your application with the ScyllaDB driver. For a detailed 
+   walkthrough of building a fictional media player application with code 
+   examples, please see our 
+   `Getting Started tutorial <https://cloud-getting-started.scylladb.com/stable/getting-started.html>`_.
+
+.. tabs::
+
+  .. group-tab:: Rust
+
+    .. code-block:: rust
+
+      use anyhow::Result;in various languages
+      use scylla::{Session, SessionBuilder};
+      use std::time::Duration;
+      #[tokio::main]
+      async fn main() -> Result<()> {
+          let session: Session = SessionBuilder::new()
+              .known_nodes(&[
+                  "localhost",
+              ])
+              .connection_timeout(Duration::from_secs(30))
+              .user("scylla", "your-awesome-password")
+              .build()
+              .await
+              .unwrap();
+
+          Ok(())
+      }
+
+  .. group-tab:: Go
+
+    .. code-block:: go
+
+      func main() {
+          cluster := gocql.NewCluster("localhost")
+
+          cluster.Authenticator = gocql.PasswordAuthenticator{Username: "scylla", Password: "your-awesome-password"}
+
+	        session, err := gocqlx.WrapSession(cluster.CreateSession())
+
+	        if err != nil {
+		          panic("Connection fail")
+	        }
+       }
+
+
+
+  .. group-tab:: Java
+
+    .. code-block:: java
+
+      import com.datastax.driver.core.Cluster;  
+      import com.datastax.driver.core.PlainTextAuthProvider;  
+      import com.datastax.driver.core.Session;  
+  
+      class Main {  
+  
+          public static void main(String[] args) {  
+          Cluster cluster = Cluster.builder()  
+              .addContactPoints("localhost")  
+              .withAuthProvider(new PlainTextAuthProvider("scylla", "your-awesome-password"))  
+              .build();  
+    
+          Session session = cluster.connect();  
+    
+          }  
+      }
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+
+      from cassandra.cluster import Cluster 
+      from cassandra.auth import PlainTextAuthProvider
+      cluster = Cluster(
+          contact_points=[
+              "localhost",
+          ],
+          auth_provider=PlainTextAuthProvider(username='scylla', password='your-awesome-password')
+      )
+
+  .. group-tab:: JavaScript
+
+    .. code-block:: javascript
+
+      const cluster = new cassandra.Client({
+          contactPoints: ["localhost", ...],
+          localDataCenter: 'your-data-center', 
+          credentials: {username: 'scylla', password: 'your-awesome-password'},
+          // keyspace: 'your_keyspace' // optional
+      })
+
+
+

--- a/docs/get-started/develop-with-scylladb/index.rst
+++ b/docs/get-started/develop-with-scylladb/index.rst
@@ -1,0 +1,21 @@
+========================
+Develop with ScyllaDB
+========================
+
+Developing with ScyllaDB involves setting up the database environment, 
+choosing the appropriate drivers for your programming language, and 
+integrating it with your application. 
+
+* :doc:`Run ScyllaDB </get-started/develop-with-scylladb/run-scylladb>`
+* :doc:`Install a Driver </get-started/develop-with-scylladb/install-drivers>`
+* :doc:`Connect an Application </get-started/develop-with-scylladb/connect-apps>`
+* :doc:`Tutorials and Example Projects </get-started/develop-with-scylladb/tutorials-example-projects>`
+
+
+.. toctree::
+  :hidden:
+
+  run-scylladb
+  install-drivers
+  connect-apps
+  tutorials-example-projects

--- a/docs/get-started/develop-with-scylladb/install-drivers.rst
+++ b/docs/get-started/develop-with-scylladb/install-drivers.rst
@@ -1,0 +1,125 @@
+===========================
+Install a Driver
+===========================
+
+To interact with ScyllaDB, you need to install the appropriate drivers for 
+your programming language. These drivers facilitate communication between 
+the application and the ScyllaDB database, enabling data manipulation and 
+retrieval.
+
+.. tabs::
+
+  .. group-tab:: Rust
+    
+    Rust developers can use specialized drivers that provide asynchronous, 
+    non-blocking access to ScyllaDB. These drivers are designed to leverage 
+    Rust's performance and safety features, ensuring efficient and secure 
+    database operations.
+
+    The installation typically involves adding the driver as a dependency in your 
+    ``Cargo.toml`` file and configuring it to connect to your ScyllaDB instance.
+
+    Run the following Cargo command in the project directory:
+
+    .. code::
+
+        cargo add scylladb
+
+    Or add the relevant version to your ``Cargo.toml`` following instructions on
+    `crates.io <https://crates.io/>`_.
+
+    * See the `Rust Driver documentation <https://rust-driver.docs.scylladb.com/>`_ for details.
+    * Learn how to use the Rust Driver on `ScyllaDB University <https://university.scylladb.com/courses/using-scylla-drivers/lessons/rust-and-scylla-2/>`_.
+
+  .. group-tab:: Python
+    
+    For Python developers, ScyllaDB has forked the Python client driver for CQL, 
+    adding enhanced capabilities that take advantage of ScyllaDB’s architecture.
+
+    ``pip`` is the suggested tool for installing packages. It will install the Python
+    driver and all required Python dependencies. Run the following command:
+
+    .. code::
+
+        pip install scylla-driver
+
+    * See the `Python Driver documentation <https://python-driver.docs.scylladb.com/>`_ for details.
+    * `Learn how to use Python with ScyllaDB <https://university.scylladb.com/courses/using-scylla-drivers/lessons/coding-with-python/>`_ on ScyllaDB University.
+
+  .. group-tab:: Java
+    
+    For Java developers, ScyllaDB has forked the Java client driver for CQL, 
+    adding enhanced capabilities that take advantage of ScyllaDB’s architecture.
+
+    Maven is the suggested tool for managing dependencies, and the driver 
+    artifacts are published in Maven central, under the group id 
+    `com.scylladb <http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.scylladb%22>`_. 
+    You should include the following dependencies:
+
+    .. code:: xml
+
+        <dependency>
+          <groupId>com.scylladb</groupId>
+          <artifactId>java-driver-core</artifactId>
+          <version>${driver.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>com.scylladb</groupId>
+          <artifactId>java-driver-query-builder</artifactId>
+          <version>${driver.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>com.scylladb</groupId>
+          <artifactId>java-driver-mapper-runtime</artifactId>
+          <version>${driver.version}</version>
+        </dependency>
+
+    * See the `Java Driver documentation <https://java-driver.docs.scylladb.com/>`_ for details.
+    * `Learn how to use Java with ScyllaDB <https://university.scylladb.com/courses/using-scylla-drivers/lessons/coding-with-java-part-1/>`_ on ScyllaDB University.
+
+  .. group-tab:: Go
+    
+    For Golang developers, ScyllaDB has forked the GoCQL client driver for CQL, 
+    adding enhanced capabilities that take advantage of ScyllaDB’s architecture.
+
+    This is a drop-in replacement for gocql, and it reuses the 
+    ``github.com/gocql/gocql`` import path. 
+
+    To install the driver:
+
+    #. Add the following line to your project ``go.mod`` file:
+
+        .. code::
+        
+            replace github.com/gocql/gocql => github.com/scylladb/gocql latest
+
+    #. Run:
+
+        .. code::
+
+            go mod tidy
+
+    * See the `Go Driver documentation <https://opensource.docs.scylladb.com/stable/using-scylla/drivers/cql-drivers/scylla-go-driver.html>`_ for details.
+    * `Learn how to use Go with ScyllaDB <https://university.scylladb.com/courses/using-scylla-drivers/lessons/golang-and-scylla-part-1/>`_ on ScyllaDB University.
+
+  .. group-tab:: JavaScript
+
+    For JavaScript developers, ScyllaDB can use the Cassandra driver for CQL.
+    ``yarn`` is the suggested tool for installing packages and required dependencies.
+
+    Run the following command:
+
+    .. code::
+
+      yarn install cassandra-driver
+
+    * Alternatively, you can use ``npm`` to install packages with the same name.
+    * `Learn how to use Node.js with ScyllaDB <https://university.scylladb.com/courses/using-scylla-drivers/lessons/scylla-and-node-js/>`_ on ScyllaDB University.
+
+
+  .. group-tab:: Other Languages
+    
+    See `ScyllaDB CQL Drivers <https://opensource.docs.scylladb.com/master/using-scylla/drivers/cql-drivers/index.html>`_ 
+    for a full list of drivers supported by ScyllaDB.

--- a/docs/get-started/develop-with-scylladb/run-scylladb.rst
+++ b/docs/get-started/develop-with-scylladb/run-scylladb.rst
@@ -1,0 +1,143 @@
+=========================
+Run ScyllaDB
+=========================
+
+ScyllaDB offers various deployment options, including Docker and ScyllaDB 
+Cloud, making it flexible for different development scenarios.
+
+* :ref:`Run ScyllaDB in Docker <create-database-docker>`
+* :ref:`Deploy with ScyllaDB Cloud (SaaS) <create-database-scylladb-cloud>`
+* :ref:`Self-deploy in the Cloud or On-premise <create-database-self-deploy>`
+
+
+.. _create-database-docker:
+
+Run ScyllaDB in Docker
+---------------------------
+Docker simplifies the deployment and management of ScyllaDB. By using Docker 
+containers, you can easily create isolated ScyllaDB instances for development, 
+testing, and production. Running ScyllaDB in Docker is the simplest way to 
+experiment with ScyllaDB, and we highly recommend it. If you intend to run 
+ScyllaDB in Docker in production, we recommend following our 
+`best practices guide <https://opensource.docs.scylladb.com/stable/operating-scylla/procedures/tips/best-practices-scylla-on-docker.html>`_.
+
+Running a Single Node
+=======================
+
+Execute the following command to run a node:
+
+.. code:: sh
+
+    docker run --name scylla -d scylladb/scylla
+
+
+Docker will start a new container named "scylla" in detached mode using 
+the ScyllaDB image, allowing it to run in the background.
+
+It will take a minute or so on a decent internet connection to pull the image 
+from Docker hub and start the container. Read on for more details on how to 
+check your node logs and status.
+
+Viewing Node Logs
+========================
+
+To view the running logs of your node, run the following command:
+
+.. code::
+
+    docker logs -f scylla
+
+
+The output of this command will look similar to this:
+
+.. code::
+    :class: hide-copy-button
+
+    INFO  2023-11-13 04:18:44,449 [shard  0] init - starting the view builder
+    INFO  2023-11-13 04:18:44,455 [shard  0] init - starting native transport
+    INFO  2023-11-13 04:18:44,456 [shard  0] cql_server_controller - Starting listening for CQL clients on 172.17.0.2:9042 (unencrypted, non-shard-aware)
+    INFO  2023-11-13 04:18:44,456 [shard  0] cql_server_controller - Starting listening for CQL clients on 172.17.0.2:19042 (unencrypted, shard-aware)
+    INFO  2023-11-13 04:18:44,457 [shard  0] init - serving
+    INFO  2023-11-13 04:18:44,457 [shard  0] init - Scylla version 5.2.9-0.20230920.5709d0043978 initialization completed.
+
+Node logs can be useful for troubleshooting and support.
+
+Checking Node Status
+======================
+
+You can verify that the cluster is up and running with the following command:
+
+.. code::
+
+    docker exec -it scylla nodetool status
+
+The output of this command will look similar to this:
+
+.. code::
+    :class: hide-copy-button
+
+    Datacenter: datacenter1
+    =======================
+    Status=Up/Down
+    |/ State=Normal/Leaving/Joining/Moving
+    --  Address     Load       Tokens       Owns    Host ID                               Rack
+    UN  172.17.0.2  632 KB     256          ?       8075882e-3b49-42a4-a742-4caf072844ff  rack1
+
+The status "UN" stands for "Up and Normal". It indicates the node is in 
+a healthy state and actively participating in the data distribution and 
+replication processes.
+
+Connecting to your Node
+========================
+
+You can connect to your node with ``cqlsh`` using the following command:
+
+.. code::
+
+     docker exec -it scylla cqlsh
+
+The output of this command will look similar to this:
+
+.. code::
+    :class: hide-copy-button
+
+    Connected to  at 172.17.0.2:9042.
+    [cqlsh 5.0.1 | Cassandra 3.0.8 | CQL spec 3.3.1 | Native protocol v4]
+    Use HELP for help.
+    cqlsh>
+
+
+.. _create-database-scylladb-cloud:
+
+Deploy with ScyllaDB Cloud (SaaS) 
+----------------------------------
+
+ScyllaDB Cloud is a fully managed service where the ScyllaDB team handles 
+deployment and maintenance of your ScyllaDB clusters. This service is ideal 
+if you're seeking a cloud-based, ready-to-use ScyllaDB solution.
+
+The easiest way to get started with ScyllaDB Cloud is to sign up for an 
+`account <https://cloud.scylladb.com/account/sign-up>`_.
+
+Follow the `Quick Start Guide to ScyllaDB Cloud <https://cloud.docs.scylladb.com/stable/scylladb-quickstart/>`_
+to launch your cluster.
+
+.. _create-database-self-deploy:
+
+Self-deploy in the Cloud or On-premise
+---------------------------------------------
+
+You can install ScyllaDB on your Linux machine using a platform-agnostic installation
+script we refer to as `ScyllaDB Web Installer for Linux <https://opensource.docs.scylladb.com/master/getting-started/installation-common/scylla-web-installer.html>`_.
+
+Run the following command to install ScyllaDB:
+
+.. code::
+
+    curl -sSf get.scylladb.com/server | sudo bash
+
+By default, running the script installs the latest official version of ScyllaDB Open Source. 
+
+Alternatively, you can install ScyllaDB packages for your platform or launch 
+ScyllaDB on AWS, GCP, or Azure. See the `download center <https://www.scylladb.com/download/>`_ 
+for a full list of options.

--- a/docs/get-started/develop-with-scylladb/tutorials-example-projects.rst
+++ b/docs/get-started/develop-with-scylladb/tutorials-example-projects.rst
@@ -1,0 +1,34 @@
+==========================================
+Tutorials and Example Projects
+==========================================
+
+The tutorials and example project will help you learn how to use ScyllaDB 
+as a data source for an application.
+
+Getting Started with ScyllaDB Cloud
+-------------------------------------
+
+`Getting Started with ScyllaDB Cloud <https://cloud-getting-started.scylladb.com/>`_ 
+is a step-by-step guide to building a Media Player project connected to 
+ScyllaDB Cloud. 
+
+It includes examples for NodeJS, Java, Python, Rust, Ruby, Elixir, C#, and
+Go.
+
+Video Streaming 
+---------------------
+
+The `Video Streaming sample application <https://github.com/scylladb/video-streaming>`_ 
+will guide you through the process of creating a video streaming 
+application using ScyllaDB Cloud and NextJS.
+
+Care Pet Project
+-------------------
+
+`Care Pet <https://iot.scylladb.com/>`_ is a step-by-step guide to building 
+an IoT project connected to ScyllaDB Cloud. 
+
+ML Feature Store
+-----------------------
+Our `Feature Store sample application and tutorial <https://feature-store.scylladb.com/>`_ help you build a real-time feature store with ScyllaDB in Python.
+

--- a/docs/get-started/index.rst
+++ b/docs/get-started/index.rst
@@ -1,0 +1,22 @@
+==============================
+Get Started with ScyllaDB
+==============================
+
+This guide will help you get started with ScyllaDB. You'll learn how to deploy ScyllaDB 
+and use it as the database for your application.
+
+.. toctree::
+   :maxdepth: 1
+   
+   why-scylladb/index
+   develop-with-scylladb/index
+   query-data/index
+   data-modeling/index
+   learn-resources/index
+
+
+
+
+
+
+

--- a/docs/get-started/learn-resources/index.rst
+++ b/docs/get-started/learn-resources/index.rst
@@ -1,0 +1,46 @@
+================================
+Learn to Use ScyllaDB
+================================
+
+ScyllaDB University
+-------------------------
+Join `ScyllaDB University <https://university.scylladb.com/>`_, which offers 
+a series of free NoSQL database training courses. They were designed as both 
+a ScyllaDB tutorial and a resource for learning basic NoSQL concepts.
+
+See the `course catalog <https://university.scylladb.com/#search-courses>`_ for
+a complete list of available courses.
+
+Example Projects
+--------------------
+ScyllaDB's :doc:`example projects </get-started/develop-with-scylladb/tutorials-example-projects/>` 
+will help you learn how to use ScyllaDB as a data source for an application.
+
+
+Webinars and Workshops
+----------------------------
+
+Attend ScyllaDB’s webinars, workshops, and other events. 
+
+`Explore the upcoming and past events <https://www.scylladb.com/company/events/>`_.
+
+Tech Talks and ScyllaDB Summit Sessions
+------------------------------------------
+
+Watch `tech talks and presentations <https://www.scylladb.com/resources/tech-talks/>`_
+from ScyllaDB's annual ScyllaDB Summit.
+
+ScyllaDB Community Forum
+-----------------------------
+
+Join the `ScyllaDB Community Forum <https://forum.scylladb.com/>`_.
+It's a public NoSQL forum to discuss ScyllaDB, an open-source distributed 
+database for data-intensive apps that require high performance and low latency.
+
+ScyllaDB Blog
+----------------
+
+Subscribe to the `ScyllaDB blog <https://www.scylladb.com/blog/>`_
+to be up to date with recent news about the ScyllaDB NoSQL database and 
+related technologies.
+

--- a/docs/get-started/query-data/cql.rst
+++ b/docs/get-started/query-data/cql.rst
@@ -1,0 +1,41 @@
+=================
+CQL
+=================
+
+CQL, or Cassandra Query Language, is a query language for interacting with 
+ScyllaDB, which is similar in syntax and usage to SQL for relational 
+databases. It allows you to define, query, and modify data. CQL is designed 
+to be simple and intuitive, making it easier for those familiar with SQL to 
+transition to working with ScyllaDB.
+
+Learning and mastering CQL is crucial for designing queries. 
+See the `ScyllaDB documentation <https://opensource.docs.scylladb.com/stable/cql/index.html>`_
+for CQL reference and CQL-related topics.
+
+Using cqlsh
+------------
+
+cqlsh is a command-line shell for interacting with ScyllaDB through CQL. It 
+provides an interface to run CQL commands and scripts. cqlsh connects to 
+a ScyllaDB node and allows you to execute CQL commands directly. This tool is 
+essential for database management tasks and querying data.
+
+You can connect to the node you started earlier in this guide, with cqlsh 
+using the following command:
+
+.. code::
+
+    docker exec -it scylla cqlsh
+
+The output of this command will look something like this:
+
+.. code::
+
+    Connected to  at 172.17.0.2:9042.
+    [cqlsh 5.0.1 | Cassandra 3.0.8 | CQL spec 3.3.1 | Native protocol v4]
+    Use HELP for help.
+    cqlsh>
+
+See `CQLSh: the CQL shell <https://opensource.docs.scylladb.com/master/cql/cqlsh.html>`_ 
+for details.
+

--- a/docs/get-started/query-data/delete-data.rst
+++ b/docs/get-started/query-data/delete-data.rst
@@ -1,0 +1,38 @@
+=======================
+Deleting Data
+=======================
+
+Delete data with the ``DELETE`` statement. Be specific with your conditions to 
+avoid accidental deletions. For example:
+
+.. code::
+
+    DELETE FROM my_keyspace.users 
+     WHERE user_id = 123e4567-e89b-12d3-a456-426655440000;
+
+Let's break down the components of this ``DELETE`` statement:
+
+**Keyspace and Table**
+
+``my_keyspace.users``: This specifies the keyspace and table from which you 
+want to delete data. In this example, you are deleting data from a table named 
+``my_table`` within the ``my_keyspace`` keyspace.
+
+**WHERE Clause**
+``WHERE user_id = 123e4567-e89b-12d3-a456-426655440000``: This part of 
+the statement specifies a condition for filtering the rows to be deleted.
+
+Including the ``WHERE`` clause with a specific condition is essential to ensure 
+that only the rows meeting the condition will be deleted. This is done to 
+prevent accidental deletions of all data in the table.
+
+In summary, the ``DELETE`` statement in ScyllaDB is used to remove existing 
+data from a table. Always use a ``WHERE`` clause with a suitable condition to 
+target the specific rows you want to delete, and ensure that the condition is 
+specific enough to avoid unintended data loss. This approach helps maintain 
+data integrity in your ScyllaDB tables.
+
+See the details about the `DELETE statement <https://opensource.docs.scylladb.com/stable/cql/dml/delete.html>`_ 
+in the ScyllaDB documentation.
+
+

--- a/docs/get-started/query-data/index.rst
+++ b/docs/get-started/query-data/index.rst
@@ -1,0 +1,20 @@
+========================
+Query Data
+========================
+
+To effectively query data in ScyllaDB, you should understand its schema and how 
+to perform basic operations like insert, read, update, and delete. 
+To perform these basic operations, you will use CQL.
+
+.. toctree::
+  :titlesonly:
+
+  cql
+  schema
+  insert-data
+  read-data
+  update-data
+  delete-data
+
+
+  

--- a/docs/get-started/query-data/insert-data.rst
+++ b/docs/get-started/query-data/insert-data.rst
@@ -1,0 +1,44 @@
+=============================
+Inserting Data
+=============================
+
+To insert data, use the ``INSERT INTO`` statement specifying the table and 
+the column values. For example:
+
+.. code::
+
+    INSERT INTO my_keyspace.users (user_id, first_name, last_name, age) 
+          VALUES (123e4567-e89b-12d3-a456-426655440000, 'Polly', 'Partition', 77);
+
+
+Let's break down the components of this ``INSERT INTO`` statement:
+
+**Keyspace and Table**
+
+``my_keyspace.users``: This specifies the keyspace and table into which you 
+want to insert data. In this example, it's inserting data into a table named 
+``users`` within the ``my_keyspace`` keyspace.
+
+**Column Names**
+
+``(user_id, first_name, last_name, age)``: This part of the statement specifies 
+the column names in the table to which you want to insert data. 
+
+**VALUES Clause**
+
+``VALUES (123e4567-e89b-12d3-a456-426655440000, 'Polly', 'Partition', 77)``: 
+This part of the statement specifies the values that you want to insert into 
+the corresponding columns. ``123e4567-e89b-12d3-a456-426655440000`` is being 
+inserted into the ``user_id`` column (without quotes) as it is an ``uuid`` data 
+type. ``'Polly', 'Partition'`` (enclosed in single quotes) are being inserted into 
+the ``first_name``, ``last_name`` columns. ``77`` is being inserted into 
+the ``age`` column (without quotes) as it is an ``int`` data type. 
+
+In summary, the ``INSERT INTO`` statement in ScyllaDB is used to insert a new 
+row of data into a specific table within a keyspace. It requires you to specify 
+the keyspace, table, column names, and the corresponding values that you want 
+to insert into those columns. This allows you to add data to your tables in 
+ScyllaDB for subsequent retrieval and querying.
+
+See the details about the `INSERT statement <https://opensource.docs.scylladb.com/stable/cql/dml/insert.html>`_ 
+in the ScyllaDB documentation.

--- a/docs/get-started/query-data/read-data.rst
+++ b/docs/get-started/query-data/read-data.rst
@@ -1,0 +1,43 @@
+======================
+Reading Data
+======================
+
+Use the ``SELECT`` statement to read data. You can specify conditions with 
+the ``WHERE`` clause. For example:
+
+.. code::
+
+    SELECT * FROM my_keyspace.users 
+     WHERE user_id = 123e4567-e89b-12d3-a456-426655440000;
+
+
+Let's break down the components of this ``SELECT`` statement:
+
+**Keyspace and Table**
+
+``my_keyspace.users``: This specifies the keyspace and table from which you 
+want to retrieve data. In this example, you are selecting data from a table 
+named ``users`` within the ``my_keyspace`` keyspace.
+
+**Columns to Retrieve**
+In this example, ``*`` is used as a wildcard character to select all columns 
+from the specified table. This means that you want to retrieve all columns of 
+data for rows that match the specified condition.
+
+**WHERE Clause**
+
+``WHERE user_id = 123e4567-e89b-12d3-a456-426655440000``: This part of 
+the statement specifies a condition for filtering the rows to retrieve.
+
+When you execute this ``SELECT`` statement, ScyllaDB will retrieve all columns 
+for rows that meet the specified condition from the ``users`` table within 
+the ``my_keyspace`` keyspace. You can use more complex conditions in 
+the ``WHERE`` clause to filter data based on various criteria.
+
+In summary, the ``SELECT`` statement in ScyllaDB is used to query data from 
+a table within a keyspace. You can specify which columns to retrieve and apply 
+filtering conditions using the ``WHERE`` clause to fetch specific rows that 
+match your criteria.
+
+See the details about the `SELECT statement <https://opensource.docs.scylladb.com/stable/cql/dml/select.html>`_ 
+in the ScyllaDB documentation.

--- a/docs/get-started/query-data/schema.rst
+++ b/docs/get-started/query-data/schema.rst
@@ -1,0 +1,130 @@
+============
+Schema
+============
+
+A schema represents the organization of data in ScyllaDB. 
+
+Keyspace
+---------------
+
+A ScyllaDB keyspace contains tables and defines settings for replication 
+and durability. To create a keyspace, use the following syntax:
+
+.. code::
+
+    CREATE KEYSPACE my_keyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};
+
+Let's break down the key concepts related to keyspace creation and replication in ScyllaDB.
+
+**Keyspace Creation**
+
+To create a keyspace, you use the ``CREATE KEYSPACE`` command followed by
+a keyspace name. In the example above, ``my_keyspace`` is the name of 
+the keyspace  you want to create. You can also specify various configuration 
+settings within the ``WITH`` clause.
+
+**Replication Strategy**
+
+Replication in ScyllaDB is the process of storing copies of data across multiple 
+nodes to ensure fault tolerance and high availability. The replication strategy 
+defines how data should be replicated across nodes in the cluster. In the example 
+above, the replication strategy is set to ``NetworkTopologyStrategy``.
+
+This is a commonly used replication strategy in ScyllaDB, especially in 
+multi-datacenter deployments. It allows you to specify the number of replicas 
+for each datacenter separately, which provides fine-grained control over data 
+distribution in a multi-datacenter environment.
+For example, if you have two datacenters, you can set different replication 
+factors for each datacenter to handle data distribution and fault tolerance 
+according to your specific requirements.
+
+**Replication Factor**
+
+The replication factor specifies how many copies (or replicas) of each piece of 
+data should be stored in the cluster. In the example above, the replication 
+factor is set to 3. This means that each piece of data will be replicated to 
+three different nodes in the cluster.
+
+The replication factor determines how many copies of your data exist across 
+the cluster and directly affects fault tolerance and read performance.
+
+Tables
+-------------
+
+Tables hold your data. Define them with specific column types and primary 
+keys. Here's how to create a table:
+
+.. code::
+
+    CREATE TABLE my_keyspace.users (
+        user_id uuid PRIMARY KEY,
+        first_name text,
+        last_name text,
+        age int
+    );
+
+Let's break down the components of this ``CREATE TABLE`` statement:
+
+**Keyspace**
+
+The ``users`` table is created within the ``my_keyspace`` keyspace. This means 
+that the ``users`` table belongs to the ``my_keyspace`` keyspace, and all data 
+stored in this table will be associated with that keyspace.
+
+**Table**
+
+The name of the table being created is ``users``. This name should be unique within the keyspace.
+
+**Columns**
+
+Columns in ScyllaDB are defined within a table and have a specified data type. 
+In the above ``users`` table, ``user_id``, ``first_name``, ``last_name``, and 
+``age`` are columns which are further explained as follows:
+
+* ``user_id``: This is a column with the data type ``uuid``. It is defined as 
+  the ``PRIMARY KEY``. The primary key uniquely identifies each row in 
+  the table and is used for efficient data retrieval.
+* ``first_name``: This is a column with the data type ``text``. It is used to store 
+  the user's first name.
+* ``last_name``: This is another column with the data type ``text``, used to store 
+  the user's last name.
+* ``age``: This is a column with the data type ``int``, used to store the user's age.
+
+In summary, the ``CREATE TABLE`` statement in ScyllaDB allows you to define 
+the structure of your table, including column names, data types, and the primary 
+key. This definition is essential for organizing and storing your data 
+efficiently within the keyspace.
+
+Primary Keys
+--------------
+
+The primary key can be made up of two parts: the partition key and optional 
+clustering columns. The ``user_id`` column is the partition key in this example. 
+It determines how data is distributed across different partitions (data shards) 
+in the cluster.
+
+Additional columns, if present, can be specified as clustering columns, which 
+determine the internal sorting of data within a partition.
+
+.. code::
+
+    CREATE TABLE my_keyspace.orders (
+        order_id uuid,
+        product_id uuid,
+        quantity int,
+        PRIMARY KEY (order_id, product_id)
+    );
+
+In this example, ``order_id`` is the partition key, and ``product_id`` is 
+the clustering key.
+
+Partitions are determined by the partition key, a part of the primary key. 
+Data is distributed across nodes based on the partition key. In the ``orders`` 
+table, ``order_id`` determines the partition.
+
+
+Learn More
+--------------
+
+* See `Data Definition <https://opensource.docs.scylladb.com/stable/cql/ddl>`_ 
+  in the ScyllDB documentation to learn more about defining a schema in ScyllaDB.

--- a/docs/get-started/query-data/update-data.rst
+++ b/docs/get-started/query-data/update-data.rst
@@ -1,0 +1,42 @@
+===================
+Updating Data
+===================
+
+Update data using the ``UPDATE`` statement. Always specify a condition to avoid 
+full-table updates. For example:
+
+.. code::
+
+    UPDATE my_keyspace.users SET age = 78 
+     WHERE user_id = 123e4567-e89b-12d3-a456-426655440000;
+
+Let's break down the components of this ``UPDATE`` statement:
+
+**Keyspace and Table**
+
+``my_keyspace.users``: This specifies the keyspace and table from which you 
+want to update data. In this example, you are updating data in a table named 
+``my_table`` within the ``my_keyspace`` keyspace.
+
+**Column Update**
+
+``SET age = 78``: This part of the statement specifies the update operation. 
+You are setting the value of the age column to ``78`` for rows that match 
+the specified condition.
+
+**WHERE Clause**
+``WHERE user_id = 123e4567-e89b-12d3-a456-426655440000``: This part of 
+the statement specifies a condition that determines which rows will be updated.
+
+By including the ``WHERE`` clause with a specific condition, you ensure that 
+only the rows that meet the condition will be updated. This is important to 
+prevent unintended updates to the entire table.
+
+In summary, the ``UPDATE`` statement in ScyllaDB is used to modify existing 
+data in a table. Always include a ``WHERE`` clause with a suitable condition 
+to target the specific rows you want to update, and specify the changes you 
+want to make using the SET clause. This helps you ensure the accuracy and 
+precision of your updates.
+
+See the details about the `UPDATE statement <https://opensource.docs.scylladb.com/stable/cql/dml/update.html>`_ 
+in the ScyllaDB documentation.

--- a/docs/get-started/why-scylladb/index.rst
+++ b/docs/get-started/why-scylladb/index.rst
@@ -1,0 +1,21 @@
+========================
+Why ScyllaDB?
+========================
+
+What is ScyllaDB?
+--------------------
+
+ScyllaDB is a high-performance, open-source NoSQL database optimized for speed 
+and scalability. It is designed to efficiently handle large volumes of data 
+with minimal latency, making it ideal for data-intensive applications. ScyllaDB 
+uses a shared-nothing architecture, contributing to its excellent performance 
+and resource utilization.
+
+Why ScyllaDB?
+--------------
+ScyllaDB is favored for its exceptional capability to manage high data volumes 
+and support rapid read/write operations. It is particularly effective in 
+environments demanding high throughput, low latency, and the ability to scale. The database is also known for its robustness and fault tolerance, 
+ensuring data integrity and availability.
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,9 +11,9 @@
 .. hero-box::
   :title: Welcome to ScyllaDB Documentation
   :image: /_static/img/mascots/scylla-docs.svg
-  :search_box:
-
-  New to ScyllaDB? Start `here <https://cloud.docs.scylladb.com/stable/scylladb-basics/>`_!
+  :button_icon: fa fa-play
+  :button_url: https://docs.scylladb.com/stable
+  :button_text: New to ScyllaDB? Start here!
 
 .. raw:: html
 
@@ -147,3 +147,9 @@
 .. raw:: html
 
   </div>
+
+
+.. toctree::
+   :hidden:
+
+   get-started/index


### PR DESCRIPTION
This PR adds documents that cover basic concepts in ScyllaDB and help developers get started with ScyllaDB.

In addition, the left navigation bar is enabled in this project so that the new documents are shown in the page tree.