### PR TITLE
add the link to the Video Streamin app tutorial docs

### DIFF
--- a/docs/get-started/develop-with-scylladb/tutorials-example-projects.rst
+++ b/docs/get-started/develop-with-scylladb/tutorials-example-projects.rst
@@ -26,7 +26,7 @@ application using ScyllaDB Cloud and NextJS.
 Video Streaming 
 ---------------------
 
-The `Video Streaming sample application <https://github.com/scylladb/video-streaming>`_ 
+The `Video Streaming sample application <https://video-streaming.scylladb.com>`_ 
 will guide you through the process of creating a video streaming 
 application using ScyllaDB Cloud and NextJS.
 


### PR DESCRIPTION
This PR replaces the link to the Video Streaming app tutorial GH repository with the link to the Video Streaming app tutorial documentation on the Tutorials and Example Projects page.