### PR TITLE
docs: fix github repo links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,6 +108,7 @@ html_css_files = [
 # documentation.
 html_theme_options = {
     "conf_py_path": "docs/",
+    "default_branch": "main",
     "hide_banner": "true",
     "hide_version_dropdown": UNSTABLE_VERSIONS,
     "hide_versions_dropdown": "true",


### PR DESCRIPTION
## Motivation

Fixes the "open an issue" and "edit this page" buttons to point to this repository.

## How to test

Clone the docs and try the buttons.

## Considerations

Consider open-sourcing this repo so external users can open issues/ edit the page. Otherwise, we could link a separate repo for issues and hide the edit on this page button, as we did for the cloud docs. cc/ @annastuchlik 

