### PR TITLE
Fix Rust driver package name

### DIFF
--- a/docs/get-started/develop-with-scylladb/install-drivers.rst
+++ b/docs/get-started/develop-with-scylladb/install-drivers.rst
@@ -23,7 +23,7 @@ retrieval.
 
     .. code::
 
-        cargo add scylladb
+        cargo add scylla
 
     Or add the relevant version to your ``Cargo.toml`` following instructions on
     `crates.io <https://crates.io/>`_.


### PR DESCRIPTION
Scylla Rust Driver crate name is scylla, not scylladb