### PR TITLE
fix: replace home icon

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@
 .. hero-box::
   :title: Welcome to ScyllaDB Documentation
   :image: /_static/img/mascots-2/docs.svg
-  :button_icon: fa fa-arrow-right
+  :button_icon: icon-arrow-right
   :button_url: https://docs.scylladb.com/stable/get-started/
   :button_text: New to ScyllaDB?
   :button_style: bold


### PR DESCRIPTION
**Motivation**

Replace the Font Awesome icon (not visible) on the homepage with the updated icon from the latest library.

**How to test**

1. Build the docs. 
2. The homepage hero box renders with the right arrow icon:

    <img width="711" alt="image" src="https://github.com/user-attachments/assets/2e8b252f-303d-4950-8f1b-c2b005c7d50c">