### PR TITLE
docs: update command 

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,6 +26,9 @@ setupenv:
 .PHONY: setup
 setup:
 	$(POETRY) install
+
+.PHONY: update
+update:
 	$(POETRY) update
 
 # Clean commands

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@
 .. hero-box::
   :title: Welcome to ScyllaDB Documentation
   :image: /_static/img/mascots-2/docs.svg
-  :button_icon: fa fa-arrow-right
+  :button_icon: icon-arrow-right
   :button_url: https://docs.scylladb.com/stable/get-started/
   :button_text: New to ScyllaDB?
   :button_style: bold


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/849

Separates the update command from the setup command.

This is required because versions now are not strictly pinned in the `pyproject.toml` file since Sphinx ScyllaDB Theme 1.8. This change makes sure that the versions defined in the ``poetry.lock`` file committed to the repository are the ones used for production builds.

## How to test

1. Build the docs locally with ``make preview``.
2. Check ``poetry.lock`` dependencies are not updated.