### PR TITLE
fix: update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   directory: "/docs"
   schedule:
     interval: "daily"
-  ignore:
-  - dependency-name: "*"
   allow:
   - dependency-name: "sphinx-scylladb-theme"
   - dependency-name: "sphinx-multiversion-scylla"


### PR DESCRIPTION
## Motivation

The exclude rule in dependabot currently takes precedence over the allow rule. This change will ensure that dependabot triggers updates only when the Sphinx theme or the multiversion extension receives an update.

## How to test

Merge the changes and verify if dependabot triggers updates as expected.