### PR TITLE
docs: add versions for enterprise and open-source docs

### DIFF
--- a/docs/_static/data/enterprise_doc_versions.json
+++ b/docs/_static/data/enterprise_doc_versions.json
@@ -1,0 +1,7 @@
+{
+    "tags": [],
+    "branches": ["enterprise", "branch-2022.2", "branch-2023.1", "branch-2024.1", "branch-2024.2"],
+    "latest": "branch-2024.2",
+    "unstable": ["enterprise"],
+    "deprecated": []
+}

--- a/docs/_static/data/opensource_doc_versions.json
+++ b/docs/_static/data/opensource_doc_versions.json
@@ -1,0 +1,7 @@
+{
+    "tags": [],
+    "branches": ["master", "branch-5.1", "branch-5.2", "branch-5.4", "branch-6.0", "branch-6.1", "branch-6.2"],
+    "latest": "branch-6.2",
+    "unstable": ["master"],
+    "deprecated": []
+}


### PR DESCRIPTION
Prepares JSON files to build enterprise and open-source documentation using JSON data hosted in this repository.

The JSON files will be published at:

*  https://docs.scylladb.com/stable/_static/data/opensource_doc_versions.json 
*  https://docs.scylladb.com/stable/_static/data/enterprise_doc_versions.json 

In the future, we can create a new JSON file that follows the same format if enterprise and open-source documentation are integrated into a single repository.

## How to test

Check that the JSON files contain all the necessary info to build versioned docs.

## Next steps

* Adapt the theme to provide a utility function for reading configuration from external URLs.
* Configure the open-source repository to read from the external URL.
* Configure the enterprise repository to read from the external URL.