### PR TITLE
Create manual_doc_versions.json

### DIFF
--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -1,0 +1,7 @@
+{
+    "tags": [],
+    "branches": ["master"],
+    "latest": "master",
+    "unstable": ["master"],
+    "deprecated": []
+}


### PR DESCRIPTION
Adds a JSON configuration for managing versions of docs.scylladb.com/manual.

The documentation will be published from the `master` branch, but we can list other versions in the future when ready.