### PR TITLE
Fix Yarn command in the 'Install Drivers' section for Node.js

### DIFF
--- a/docs/get-started/develop-with-scylladb/install-drivers.rst
+++ b/docs/get-started/develop-with-scylladb/install-drivers.rst
@@ -113,7 +113,7 @@ retrieval.
 
     .. code::
 
-      yarn install cassandra-driver
+      yarn add cassandra-driver
 
     * Alternatively, you can use ``npm`` to install packages with the same name.
     * `Learn how to use Node.js with ScyllaDB <https://university.scylladb.com/courses/using-scylla-drivers/lessons/scylla-and-node-js/>`_ on ScyllaDB University.


### PR DESCRIPTION
This PR introduces a small correction to the 'Install Drivers' section for Node.js. Specifically, it updates the incorrect Yarn command `yarn install cassandra-driver` to the correct command `yarn add cassandra-driver`. This ensures that users can properly follow the instructions without encountering issues.