### PR TITLE
Publish the docs for 2025.1

### DIFF
--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -1,7 +1,7 @@
 {
     "tags": [],
-    "branches": ["branch-6.2", "master"],
-    "latest": "branch-6.2",
+    "branches": ["master", "branch-2025.1"],
+    "latest": "branch-2025.1",
     "unstable": ["master"],
     "deprecated": []
 }


### PR DESCRIPTION
This commit enables publishing the docs for version 2025.1.

Fixes https://github.com/scylladb/scylladb-docs-homepage/issues/41