### PR TITLE
chore: react to changes on manual_doc_versions.json

### DIFF
--- a/.github/workflows/docs-manual.yaml
+++ b/.github/workflows/docs-manual.yaml
@@ -4,6 +4,11 @@ env:
   FLAG: 'manual'
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/_static/data/manual_doc_versions.json"
   schedule:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'


### PR DESCRIPTION
ScyllaDB Manual will now publish when the "docs/_static/data/manual_doc_versions.json" file receives an edit.

Additionally, it will still building once a day and if you run the workflow manually from the GitHub Actions tab.