### PR TITLE
doc: set 2025.1 as unstable

### DIFF
--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -1,7 +1,7 @@
 {
     "tags": [],
-    "branches": ["master", "branch-2025.1"],
-    "latest": "branch-2025.1",
-    "unstable": ["master"],
+    "branches": ["master", "branch-2025.1", "branch-6.2"],
+    "latest": "branch-6.2",
+    "unstable": ["master", "branch-2025.1"],
     "deprecated": []
 }


### PR DESCRIPTION
This commit sets branch-2025.1 as unstable because version 2025.1 has not been released yet.
Temporarily, version 6.2 is set as the latest stable.