### PR TITLE
replace the link to the ScyllaDB docs on the landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@
 .. topic-box::
   :title: ScyllaDB
   :icon: icon-instance
-  :link: https://docs.scylladb.com/manual
+  :link: https://enterprise.docs.scylladb.com/branch-2024.2
   :link_target: _self
   :class: large-4 self-hosted-card
   :anchor: ScyllaDB Docs


### PR DESCRIPTION
As a temporary solution, replace https://docs.scylladb.com/manual with https://enterprise.docs.scylladb.com/branch-2024.2 until 2025.1 is released.