### PR TITLE
fix: homepage responsive view

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -4,14 +4,40 @@
     margin-bottom: 0;
 }
 
+.landing__content .alert a {
+    color: #fff;
+}
+
+
+.side-nav__title,
+.landing__content .alert{
+    display: none;
+}
+
+.hero__img {
+    top: -20px;
+}
+
+
+@media screen and (min-width: 460px) {
+    .hero__img {
+        top: 20px;
+    }    
+}
+
 @media screen and (min-width: 640px) {
     .hero__title {
         max-width: 550px;
     }
+
+    
 }
 
-@media screen and (max-width: 1020px) {
-   .side-nav__title{
-    display: none;
-   }
+@media screen and (min-width: 1020px) {
+
+    .side-nav__title,
+    .landing__content .alert {
+        display: flex;
+    }
+   
 }


### PR DESCRIPTION
Fixes the homepage responsive view by hiding the alert.

Before:

![image](https://github.com/user-attachments/assets/dd7d4da5-6585-45b3-8cd7-2d68e4a9cef5)

Now:

![image](https://github.com/user-attachments/assets/c198118c-220f-4228-a9ad-b5d8d20792fb)
