### PR TITLE
set version 2025.1 as latest stable

### DIFF
--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -1,7 +1,7 @@
 {
     "tags": [],
-    "branches": ["master", "branch-2025.1", "branch-6.2"],
-    "latest": "branch-6.2",
-    "unstable": ["master", "branch-2025.1"],
+    "branches": ["master", "branch-2025.1"],
+    "latest": "branch-2025.1",
+    "unstable": ["master"],
     "deprecated": []
 }


### PR DESCRIPTION
⚠️ DO NOT MERGE. This PR can only be merged when version 2025.1 is released. Wait for the green light from @tzach. 

This PR sets 2025.1 as the latest stable version (the default when you go to https://docs.scylladb.com/manual/) and removes version 6.2 from this set of docs - we used it only temporarily before releasing 2025.1.