### PR TITLE
fix: static redirection

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -5,7 +5,7 @@
 # removing "Enterprise" from the file name
 
 /stable/versioning/version-support-enterprise.html: /stable/versioning/version-support.html
-/stable/_static/data/enterprise_supported_versions.json: /stable/_static/data/supported_versions.json
+/stable/_static/data/enterprise_supported_versions.json/index.html: /stable/_static/data/supported_versions.json
 
 # moving Glossary under Reference (starting from version 5.3)
 # needs to be replaced with the following when 5.3 is released:


### PR DESCRIPTION
Fixes the redirection from `stable/_static/data/enterprise_supported_versions.json` to `/stable/_static/data/supported_versions.json`.

Explanation: Redirection files must end with `.html`. To address this, we create a directory named `enterprise_supported_versions.json` with an `index.html` file inside, which most browsers will handle correctly.

### How to test 

1. Merge this PR.  
2. Access `https://docs.scylladb.com/stable/_static/data/enterprise_supported_versions.json`.  
3. It should redirect to the new file.  
