### PR TITLE
add ScyllaDB 2025.1 to the Version Support list

### DIFF
--- a/docs/_static/data/supported_versions.json
+++ b/docs/_static/data/supported_versions.json
@@ -1,5 +1,12 @@
 {
   "data": [
+    {
+        "version": "ScyllaDB 2025.1 (LTS)",
+        "released": "April 2025",
+        "status": "Supported",
+        "end_of_life": "After 2027.1 is released",
+        "show_version_policy_link": true
+    },
       {
           "version": "Enterprise 2024.2",
           "released": "November 2024",
@@ -17,9 +24,9 @@
       {
           "version": "Enterprise 2023.1 (LTS)",
           "released": "August 2023",
-          "status": "Supported",
-          "end_of_life": "After 2025.1 is released",
-          "show_version_policy_link": true
+          "status": " Not supported",
+          "end_of_life": "April 2025",
+          "show_version_policy_link": false
       },
       {
           "version": "Enterprise 2022.2",


### PR DESCRIPTION
This PR adds support for version 2025.1 and removes support for 2023.1.