### PR TITLE
update the link to the main ScyllaDB documention

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@
 .. topic-box::
   :title: ScyllaDB
   :icon: icon-instance
-  :link: https://enterprise.docs.scylladb.com/branch-2024.2
+  :link: https://docs.scylladb.com/manual/stable/
   :link_target: _self
   :class: large-4 self-hosted-card
   :anchor: ScyllaDB Docs


### PR DESCRIPTION
Replace the temporary link to the Enterprise docs with the link to the new documentation set at https://docs.scylladb.com/manual/stable/