### PR TITLE
remove support for Enterprise 2023.1

### DIFF
--- a/docs/_static/data/supported_versions.json
+++ b/docs/_static/data/supported_versions.json
@@ -24,9 +24,9 @@
       {
           "version": "Enterprise 2023.1 (LTS)",
           "released": "August 2023",
-          "status": "Supported",
-          "end_of_life": "After 2025.1 is released",
-          "show_version_policy_link": true
+          "status": "Not supported",
+          "end_of_life": "April 2025",
+          "show_version_policy_link": false
       },
       {
           "version": "Enterprise 2022.2",


### PR DESCRIPTION
This PR removes support for ScyllaDB Enterprise 2023.1 from the list of supported versions at https://docs.scylladb.com/stable/versioning/version-support.html.

@tzach FYI 