### PR TITLE
docs: enable ai chatbot

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,7 @@ html_css_files = [
 # documentation.
 html_theme_options = {
     "conf_py_path": "docs/",
+    "hide_ai_chatbot": "false",
     "default_branch": "main",
     "hide_banner": "true",
     "hide_version_dropdown": UNSTABLE_VERSIONS,


### PR DESCRIPTION
Adds an AI chatbot to ScyllaDB docs powered by [Biel.ai](https://biel.ai).

**Details:** https://sphinx-theme.scylladb.com/stable/configuration/ai-chatbot.html