### PR TITLE
remove master from published versions for Open Source

### DIFF
--- a/docs/_static/data/opensource_doc_versions.json
+++ b/docs/_static/data/opensource_doc_versions.json
@@ -1,7 +1,7 @@
 {
     "tags": [],
-    "branches": ["master", "branch-5.1", "branch-5.2", "branch-5.4", "branch-6.0", "branch-6.1", "branch-6.2"],
+    "branches": ["branch-5.1", "branch-5.2", "branch-5.4", "branch-6.0", "branch-6.1", "branch-6.2"],
     "latest": "branch-6.2",
-    "unstable": ["master"],
+    "unstable": [],
     "deprecated": []
 }


### PR DESCRIPTION
This PR removes the master branch from the list of branches published to https://opensource.docs.scylladb.com/.

- The master branch no longer shows updates that are OSS.
- The master branch on OSS is indexed by Google, which is misleading the users.

Approved by @tzach.