### PR TITLE
doc: update the status of 2025.2 in supported versions

### DIFF
--- a/docs/_static/data/supported_versions.json
+++ b/docs/_static/data/supported_versions.json
@@ -2,9 +2,9 @@
   "data": [
         {
         "version": "ScyllaDB 2025.2",
-        "released": "Pre-release",
-        "status": "Next",
-        "end_of_life": "According to the policy",
+        "released": "July 2025",
+        "status": "Supported",
+        "end_of_life": "After 2027.1, 2026.2 or 2025.4 is released",
         "show_version_policy_link": true
     },
     {
@@ -17,8 +17,8 @@
       {
           "version": "Enterprise 2024.2",
           "released": "November 2024",
-          "status": "Supported",
-          "end_of_life": "After 2026.1 or 2025.2 is released",
+          "status": "Not supported",
+          "end_of_life": "July 2025",
           "show_version_policy_link": true
       },
       {


### PR DESCRIPTION
This commit updates the status of 2025.2 following the release of that version.

Also, it removes support for 2024.2, according to the policy and the release notes.