### PR TITLE
publish the docs for 2025.3

### DIFF
--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -1,7 +1,7 @@
 {
     "tags": [],
-    "branches": ["master", "branch-2025.1", "branch-2025.2"],
+    "branches": ["master", "branch-2025.1", "branch-2025.2","branch-2025.3"],
     "latest": "branch-2025.2",
-    "unstable": ["master"],
+    "unstable": ["master", "branch-2025.3"],
     "deprecated": []
 }


### PR DESCRIPTION
Following the branching, this PR enables publication for version 2025.3 and sets the version as unstable.

Fixes https://github.com/scylladb/scylladb/issues/24755

@tzach fyi