### PR TITLE
doc: add the driver support policy

### DIFF
--- a/docs/versioning/driver-support.rst
+++ b/docs/versioning/driver-support.rst
@@ -1,0 +1,31 @@
+========================
+Driver Support Policy
+========================
+
+Driver Support Policy
+-------------------------------
+
+We support the **two most recent minor releases** of our drivers.
+
+* We test and validate the latest two minor versions.
+* We typically patch only the latest minor release.
+
+We recommend staying up to date with the latest supported versions to receive
+updates and fixes.
+
+At a minimum, upgrade your driver when upgrading to a new ScyllaDB version
+to ensure compatibility between the driver and the database.
+
+ScyllaDB Drivers
+-----------------
+
+The following ScyllaDB drivers are available:
+
+* `Python Driver <https://python-driver.docs.scylladb.com/>`_
+* `Java Driver <https://java-driver.docs.scylladb.com/>`_
+* `Go Driver <https://github.com/scylladb/gocql>`_
+* `Go Extension <https://github.com/scylladb/gocqlx>`_
+* `C++ Driver <https://cpp-driver.docs.scylladb.com/>`_
+* `CPP-over-Rust Driver <https://github.com/scylladb/cpp-rust-driver>`_
+* `Rust Driver <https://rust-driver.docs.scylladb.com/>`_
+

--- a/docs/versioning/index.rst
+++ b/docs/versioning/index.rst
@@ -6,3 +6,4 @@ Versioning and Support Policy
    :maxdepth: 1
 
    version-support
+   driver-support


### PR DESCRIPTION
This PR adds the driver support policy to the Versioning and Support Policy section of the unversioned documentation.