### PR TITLE
remove the Source Available alert from the landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,14 +24,6 @@
 
   <div class="topics-grid grid-container full">
 
-.. alert::
-  :link: https://www.scylladb.com/2024/12/18/why-were-moving-to-a-source-available-license/
-  :target: _blank
-  :link_text: Learn more about the change
-  :icon: logs
-
-   We’re updating our license & versioning policy
-
 .. raw:: html
 
   <div class="grid-x grid-margin-x hs">


### PR DESCRIPTION
The banner with the alert was temporary. It was used to inform users that we introduced a new license and versioning policy. It's no longer needed.

Fixes https://github.com/scylladb/scylladb-docs-homepage/issues/82