### PR TITLE
add 2025.3 to Supported Versions

### DIFF
--- a/docs/_static/data/supported_versions.json
+++ b/docs/_static/data/supported_versions.json
@@ -1,6 +1,13 @@
 {
   "data": [
         {
+        "version": "ScyllaDB 2025.3",
+        "released": "September 2025",
+        "status": "Supported",
+        "end_of_life": "After 2027.1 or 2026.2 is released",
+        "show_version_policy_link": true
+    },
+        {
         "version": "ScyllaDB 2025.2",
         "released": "July 2025",
         "status": "Supported",


### PR DESCRIPTION
This PR adds version 2025.3 to the list
of supported versions.

Fixes https://github.com/scylladb/scylladb-docs-homepage/issues/85