### PR TITLE
update the EOL for 2025.2 and 2025.3

### DIFF
--- a/docs/_static/data/supported_versions.json
+++ b/docs/_static/data/supported_versions.json
@@ -4,14 +4,14 @@
         "version": "ScyllaDB 2025.3",
         "released": "September 2025",
         "status": "Supported",
-        "end_of_life": "After 2027.1 or 2026.2 is released",
+        "end_of_life": "After 2026.2 is released",
         "show_version_policy_link": true
     },
         {
         "version": "ScyllaDB 2025.2",
         "released": "July 2025",
         "status": "Supported",
-        "end_of_life": "After 2027.1, 2026.2 or 2025.4 is released",
+        "end_of_life": "After 2025.4 is released",
         "show_version_policy_link": true
     },
     {


### PR DESCRIPTION
This PR removes the redundant and confusing information about when the releases may reach End of Life.

Now that the releases are predictable, we can remove the list of all the releases that MAY potentially remove support for 2025.2 and 2025.3, and leave the ones that WILL.

Per discussion with @tzach. Please review.