### PR TITLE
publish the docs for 2025.4

### DIFF
--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -1,7 +1,7 @@
 {
     "tags": [],
-    "branches": ["master", "branch-2025.1", "branch-2025.2","branch-2025.3"],
+    "branches": ["master", "branch-2025.1", "branch-2025.2","branch-2025.3", "branch-2025.4"],
     "latest": "branch-2025.3",
-    "unstable": ["master"],
+    "unstable": ["master", "branch-2025.3"],
     "deprecated": []
 }


### PR DESCRIPTION
Following the branching, this PR enables publication for version 2025.4 and sets the version as unstable.

Fixes https://github.com/scylladb/scylladb-docs-homepage/issues/97
Fixes https://github.com/scylladb/scylladb/issues/26343