### PR TITLE
publish the docs for 2026.2 as unstable

### DIFF
--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -1,7 +1,7 @@
 {
     "tags": [],
-    "branches": ["master", "branch-2025.1", "branch-2025.2", "branch-2025.3", "branch-2025.4", "branch-2026.1"],
+    "branches": ["master", "branch-2025.1", "branch-2025.2", "branch-2025.3", "branch-2025.4", "branch-2026.1","branch-2026.2"],
     "latest": "branch-2026.1",
-    "unstable": ["master"],
+    "unstable": ["master", "branch-2026.2"],
     "deprecated": ["branch-2025.2", "branch-2025.3"]
 }


### PR DESCRIPTION
This PR enables publishing the docs for version 2026.2 and marks that version as unstable (pre-release).

Fixes https://github.com/scylladb/scylladb/issues/29651

Fixes SCYLLADB-1750