### PR TITLE
add OS support for version 2026.2

### DIFF
--- a/docs/_static/data/os-support.json
+++ b/docs/_static/data/os-support.json
@@ -7,6 +7,15 @@
     },
     "ScyllaDB Versions": [
       {
+        "version": "ScyllaDB 2026.2",
+        "supported_OS": {
+          "Ubuntu": ["22.04", "24.04"],
+          "Debian": ["11", "12"],
+          "Rocky / CentOS / RHEL": ["8", "9", "10"],
+          "Amazon Linux": ["2023"]
+        }
+      },
+      {
         "version": "ScyllaDB 2026.1",
         "supported_OS": {
           "Ubuntu": ["22.04", "24.04"],


### PR DESCRIPTION
⚠️ Do not merge before 2026.2 is released.

This PR adds OS support for 2026.2 based on the input from the RelEng team, see https://scylladb.atlassian.net/browse/SCYLLADB-1768?focusedCommentId=53697

Fixes SCYLLADB-1768