### PR TITLE
add the Node.js RS Driver documentation links

### DIFF
--- a/docs/drivers/cql-drivers.rst
+++ b/docs/drivers/cql-drivers.rst
@@ -92,7 +92,7 @@ Click the documentation link to view the documentation for each driver.
           it provides fully asynchronous operations, efficient resource usage,
           and high-throughput, low-latency database access for Node.js applications.
 
-        `Node.js RS Driver documentation <https://github.com/scylladb/nodejs-rs-driver/>`_
+        `Node.js RS Driver documentation <https://nodejs-rs-driver.docs.scylladb.com/>`_
 
     * - C++ Driver
       - | This driver is no longer actively maintained. We recommend using

--- a/docs/versioning/driver-support.rst
+++ b/docs/versioning/driver-support.rst
@@ -53,6 +53,6 @@ versions.
       - * 1.0
     * - `C++ Driver <https://cpp-driver.docs.scylladb.com/>`_
       - Deprecated. Migrate to `CPP RS Driver <https://cpp-rs-driver.docs.scylladb.com/>`_.
-    * - `Node.js RS Driver <https://github.com/scylladb/nodejs-rs-driver/>`_
+    * - `Node.js RS Driver <https://nodejs-rs-driver.docs.scylladb.com/>`_
       - * 0.5 (Beta)
 


### PR DESCRIPTION
The documentation for the driver is now published, so the links to the repository are replaced with
the links to the published documentation.