### PR TITLE
Surface Drivers, Versioning, and Tutorials on the landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@
 
 .. raw:: html
 
-  <div class="grid-x grid-margin-x hs">
+  <div class="grid-x grid-margin-x">
 
 .. topic-box::
   :title: Getting started
@@ -59,15 +59,6 @@
 
   Deploy and manage your database in your environment.
 
-
-.. raw:: html
-
-  </div></div>
-
-.. raw:: html
-
-  <div class="grid-x grid-margin-x hs">
-
 .. topic-box::
   :title: ScyllaDB Drivers
   :icon: icon-link
@@ -76,7 +67,7 @@
   :class: large-4 drivers-card
   :anchor: Drivers
 
-  Connect your application to ScyllaDB with shard-aware CQL and DynamoDB-compatible drivers.
+  Connect your application with shard-aware CQL and DynamoDB-compatible drivers.
 
 .. topic-box::
   :title: Versioning and Support Policy
@@ -84,9 +75,9 @@
   :link: https://docs.scylladb.com/stable/versioning/index.html
   :link_target: _self
   :class: large-4 versioning-card
-  :anchor: Versioning and Support Policy
+  :anchor: Versioning Policy
 
-  Learn which ScyllaDB versions, drivers, and operating systems are supported and for how long.
+  See which versions, drivers, and operating systems are supported.
 
 .. topic-box::
   :title: Tutorials and Example Projects
@@ -94,9 +85,9 @@
   :link: https://docs.scylladb.com/stable/get-started/develop-with-scylladb/tutorials-example-projects.html
   :link_target: _self
   :class: large-4 tutorials-card
-  :anchor: Tutorials and Example Projects
+  :anchor: Tutorials
 
-  Build real applications with step-by-step tutorials and ready-to-run sample projects.
+  Build real applications with step-by-step tutorials and sample projects.
 
 
 .. raw:: html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,22 +66,52 @@
 
 .. raw:: html
 
+  <div class="grid-x grid-margin-x hs">
+
+.. topic-box::
+  :title: ScyllaDB Drivers
+  :icon: icon-link
+  :link: https://docs.scylladb.com/stable/drivers/index.html
+  :link_target: _self
+  :class: large-4 drivers-card
+  :anchor: Drivers
+
+  Connect your application to ScyllaDB with shard-aware CQL and DynamoDB-compatible drivers.
+
+.. topic-box::
+  :title: Versioning and Support Policy
+  :icon: icon-support
+  :link: https://docs.scylladb.com/stable/versioning/index.html
+  :link_target: _self
+  :class: large-4 versioning-card
+  :anchor: Versioning and Support Policy
+
+  Learn which ScyllaDB versions, drivers, and operating systems are supported and for how long.
+
+.. topic-box::
+  :title: Tutorials and Example Projects
+  :icon: icon-docs-training
+  :link: https://docs.scylladb.com/stable/get-started/develop-with-scylladb/tutorials-example-projects.html
+  :link_target: _self
+  :class: large-4 tutorials-card
+  :anchor: Tutorials and Example Projects
+
+  Build real applications with step-by-step tutorials and ready-to-run sample projects.
+
+
+.. raw:: html
+
+  </div></div>
+
+.. raw:: html
+
   <div class="topics-grid topics-grid--products">
 
-      <h2 class="topics-grid__title">Other Products</h2>
-      <p class="topics-grid__text"></p>
+      <h2 class="topics-grid__title">Manage, Monitor, and Migrate</h2>
+      <p class="topics-grid__text">Tools to manage and monitor your ScyllaDB clusters, and help you migrate to ScyllaDB.</p>
 
       <div class="grid-container full">
           <div class="grid-x grid-margin-x">
-
-.. topic-box::
-  :title: ScyllaDB Alternator
-  :link: https://docs.scylladb.com/manual/stable/alternator/alternator.html
-  :link_target: _self
-  :image: /_static/img/mascots-2/alternator.svg
-  :class: topic-box--product,large-4,small-6
-
-  Amazon DynamoDB-compatible API.
 
 .. topic-box::
   :title: ScyllaDB Monitoring Stack
@@ -102,13 +132,36 @@
   Hassle-free ScyllaDB NoSQL database management for scale-out clusters.
 
 .. topic-box::
-  :title: ScyllaDB Drivers
-  :link: https://docs.scylladb.com/manual/stable/using-scylla/drivers/
+  :title: ScyllaDB Migrator
+  :link: https://migrator.docs.scylladb.com
   :link_target: _self
-  :image: /_static/img/mascots-2/driver.svg
+  :image: /_static/img/mascots/scylla-migrator.svg
   :class: topic-box--product,large-4,small-6
 
-  Shard-aware drivers for superior performance. 
+  Migrate data to ScyllaDB using Spark.
+
+.. raw:: html
+
+  </div></div></div>
+
+.. raw:: html
+
+  <div class="topics-grid topics-grid--products">
+
+      <h2 class="topics-grid__title">DynamoDB API &amp; Kubernetes</h2>
+      <p class="topics-grid__text">Use ScyllaDB through the DynamoDB-compatible API or run it on Kubernetes.</p>
+
+      <div class="grid-container full">
+          <div class="grid-x grid-margin-x">
+
+.. topic-box::
+  :title: ScyllaDB Alternator
+  :link: https://docs.scylladb.com/manual/stable/alternator/alternator.html
+  :link_target: _self
+  :image: /_static/img/mascots-2/alternator.svg
+  :class: topic-box--product,large-4,small-6
+
+  Use the Amazon DynamoDB-compatible API.
 
 .. topic-box::
   :title: ScyllaDB Operator
@@ -117,17 +170,7 @@
   :image: /_static/img/mascots-2/operator.svg
   :class: topic-box--product,large-4,small-6
 
-  Easily run and manage your ScyllaDB cluster on Kubernetes.
-
-
-.. topic-box::
-  :title: ScyllaDB Migrator
-  :link: https://migrator.docs.scylladb.com
-  :link_target: _self
-  :image: /_static/img/mascots/scylla-migrator.svg
-  :class: topic-box--product,large-4,small-6
-
-  Migrate data extract using Spark to ScyllaDB.
+  Run and manage ScyllaDB on Kubernetes.
 
 .. raw:: html
 


### PR DESCRIPTION
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2880

## What

The landing page at `docs.scylladb.com/stable` only linked to the **Getting Started** part of the homepage doc set, even though that doc set has three top-level sections: **Get Started**, **Drivers**, and **Versioning and Support Policy**. The Drivers and Versioning sections had no easy access from the landing page.

This PR adds a second row of boxes (matching the existing 3-box first row) so the rest of that doc set is reachable directly from the landing page, without introducing a sidebar.

**New second row (3 boxes):**
| Box | Link |
| --- | --- |
| ScyllaDB Drivers | `https://docs.scylladb.com/stable/drivers/index.html` |
| Versioning and Support Policy | `https://docs.scylladb.com/stable/versioning/index.html` |
| Tutorials and Example Projects | `https://docs.scylladb.com/stable/get-started/develop-with-scylladb/tutorials-example-projects.html` |

## Also fixes a broken link

The **ScyllaDB Drivers** box under **Other Products** pointed to the server manual (`/manual/stable/using-scylla/drivers/`) instead of this doc set's own drivers section. Drivers now lives in the new row and points to the correct `/stable/drivers/index.html`, so the duplicate/mis-pointed box has been removed from **Other Products** (which now has 5 boxes).

## Unchanged (as required)

- First row of boxes is untouched: **Getting Started**, **ScyllaDB Cloud**, **ScyllaDB**.
- Links/boxes to **ScyllaDB Cloud docs** and **ScyllaDB docs** remain.
- Immediate access to **Getting Started** is preserved.
- No sidebar/menu added.

## Verification

- `uv run sphinx-build -b dirhtml -W --keep-going` builds clean (warnings-as-errors), no warnings/errors.
- Generated `index.html` confirmed: new links present, the old `/manual/.../drivers/` reference is gone.

> Note: visual review of the rendered landing page (spacing/responsive behavior of the new row) is worth a look in the build preview.