### PR TITLE
set version 2026.2 as the latest stable

### DIFF
--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -1,7 +1,7 @@
 {
     "tags": [],
     "branches": ["master", "branch-2025.1", "branch-2025.2", "branch-2025.3", "branch-2025.4", "branch-2026.1","branch-2026.2"],
-    "latest": "branch-2026.1",
-    "unstable": ["master", "branch-2026.2"],
+    "latest": "branch-2026.2",
+    "unstable": ["master"],
     "deprecated": ["branch-2025.2", "branch-2025.3"]
 }


### PR DESCRIPTION
This PR sets 2026.2 as the latest stable version (the default when you go to https://docs.scylladb.com/manual/).

Fixes SCYLLADB-1751