### PR TITLE
publish the docs for 2026.3 as unstable

### DIFF
--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -3,5 +3,5 @@
     "branches": ["master", "branch-2025.1", "branch-2025.2", "branch-2025.3", "branch-2025.4", "branch-2026.1","branch-2026.2", "branch-2026.3"],
     "latest": "branch-2026.2",
     "unstable": ["master", "branch-2026.3"],
-    "deprecated": ["branch-2025.2", "branch-2025.3"]
+    "deprecated": ["branch-2025.2", "branch-2025.3", "branch-2025.4"]
 }

--- a/docs/_static/data/manual_doc_versions.json
+++ b/docs/_static/data/manual_doc_versions.json
@@ -1,7 +1,7 @@
 {
     "tags": [],
-    "branches": ["master", "branch-2025.1", "branch-2025.2", "branch-2025.3", "branch-2025.4", "branch-2026.1","branch-2026.2"],
+    "branches": ["master", "branch-2025.1", "branch-2025.2", "branch-2025.3", "branch-2025.4", "branch-2026.1","branch-2026.2", "branch-2026.3"],
     "latest": "branch-2026.2",
-    "unstable": ["master"],
+    "unstable": ["master", "branch-2026.3"],
     "deprecated": ["branch-2025.2", "branch-2025.3"]
 }


### PR DESCRIPTION
This PR enables publishing the docs for version 2026.3 and marks that version as unstable (pre-release).
In addition, marks the documentation for 2025.4 as deprecated, because the version is no longer supported.

Fixes https://github.com/scylladb/scylladb/issues/30795
Fixes SCYLLADB-3311